### PR TITLE
Handle virtual collisions [fixed source and transportDT only]

### DIFF
--- a/CollisionOperator/collisionOperator_class.f90
+++ b/CollisionOperator/collisionOperator_class.f90
@@ -114,7 +114,7 @@ contains
     class(particleDungeon),intent(inout)     :: thisCycle
     class(particleDungeon),intent(inout)     :: nextCycle
     integer(shortInt)                        :: idx, procType
-    character(100), parameter :: Here = 'collide ( collisionOperator_class.f90)'
+    character(100), parameter :: Here = 'collide (collisionOperator_class.f90)'
 
     ! Select processing index with ternary expression
     if(p % isMG) then
@@ -140,5 +140,5 @@ contains
     call self % physicsTable(idx) % proc % collide(p, tally, thisCycle, nextCycle)
 
   end subroutine collide
-    
+
 end module collisionOperator_class

--- a/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
+++ b/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
@@ -413,6 +413,9 @@ contains
     allocate(self % tally)
     call self % tally % init(tempDict)
 
+    !handling of virtual collisions enabled? check compatability if so
+    call self % tally % handleVirtualCollisions(dict)
+
     ! Size particle dungeon
     ! Note no need to oversize for fixed source calculation
     allocate(self % thisCycle)

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -869,6 +869,8 @@ The **tally clerks** determine which kind of estimator will be used. The options
     that defines the domains of integration of each tally
   - filter (*optional*): can filter out particles with certain properties,
     preventing them from scoring results
+  - handleVirtual (*optional*): if set to 1 handles virtual as well as physical
+    collisions (currently only valid for fixed source and transportDT operator)
 
 * trackClerk
 


### PR DESCRIPTION
Seems like I need to let both the collision clerk and transport operator know about virtual collisions wanting to be handled so that 1) majorant XS used for scoring in collision clerk and 2) report both physical and virtual collisions but avoiding colliding in void material. So I went through tally admin in fixed source physics package to do this. Also makes compatability check to ensure that virtual collisions handled only when one tally clerk (collision clerk) defined and transportDT operator.



